### PR TITLE
설문조사 만들고, 조회하는 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'javax.validation:validation-api:2.0.1.Final'
 	testImplementation group: 'com.h2database', name: 'h2', version: '2.2.224'
 	runtimeOnly 'com.h2database:h2'
 

--- a/src/main/java/com/pnu/sursim/domain/gpt/service/GptService.java
+++ b/src/main/java/com/pnu/sursim/domain/gpt/service/GptService.java
@@ -35,7 +35,7 @@ public class GptService {
             result = om.readValue(response.getBody(), new TypeReference<>() {
             });
         } catch (Exception e) {
-            throw new CustomException(e);
+            System.out.println("e = " + e);
         }
         return result;
     }
@@ -58,7 +58,7 @@ public class GptService {
             resultMap = om.readValue(response.getBody(), new TypeReference<>() {
             });
         } catch (Exception e) {
-            throw new CustomException(e);
+            System.out.println("e = " + e);
         }
         return resultMap;
     }

--- a/src/main/java/com/pnu/sursim/domain/survey/controller/SurveyController.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/controller/SurveyController.java
@@ -5,6 +5,7 @@ import com.pnu.sursim.domain.survey.dto.SurveyResponse;
 import com.pnu.sursim.domain.survey.service.SurveyService;
 import com.pnu.sursim.domain.user.dto.AuthUser;
 import com.pnu.sursim.global.auth.resolver.SessionUser;
+import com.pnu.sursim.global.response.CustomPage;
 import com.pnu.sursim.global.response.CustomResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,7 +29,7 @@ public class SurveyController {
     @GetMapping("/surveys/all")
     public CustomResponse getSurveysForAll(@SessionUser AuthUser authUser,Pageable pageable) {
         Page<SurveyResponse> surveyResponsePage = surveyService.getSurveysForAll(authUser.getEmail(),pageable);
-        return CustomResponse.success(surveyResponsePage);
+        return CustomResponse.success(new CustomPage(surveyResponsePage));
     }
 
     @GetMapping("/surveys")

--- a/src/main/java/com/pnu/sursim/domain/survey/controller/SurveyController.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/controller/SurveyController.java
@@ -1,0 +1,28 @@
+package com.pnu.sursim.domain.survey.controller;
+
+import com.pnu.sursim.domain.survey.dto.SurveyRequest;
+import com.pnu.sursim.domain.survey.service.SurveyService;
+import com.pnu.sursim.domain.user.dto.AuthUser;
+import com.pnu.sursim.global.auth.resolver.SessionUser;
+import com.pnu.sursim.global.response.CustomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SurveyController {
+
+    private final SurveyService surveyService;
+
+    @PostMapping("/survey")
+    public CustomResponse createSurvey(@SessionUser AuthUser authUser, @RequestBody SurveyRequest surveyRequest) {
+        surveyService.createSurvey(authUser.getEmail(),surveyRequest);
+        return CustomResponse.success("Survey created successfully");
+    }
+
+
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/controller/SurveyController.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/controller/SurveyController.java
@@ -1,15 +1,17 @@
 package com.pnu.sursim.domain.survey.controller;
 
 import com.pnu.sursim.domain.survey.dto.SurveyRequest;
+import com.pnu.sursim.domain.survey.dto.SurveyResponse;
 import com.pnu.sursim.domain.survey.service.SurveyService;
 import com.pnu.sursim.domain.user.dto.AuthUser;
 import com.pnu.sursim.global.auth.resolver.SessionUser;
 import com.pnu.sursim.global.response.CustomResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -18,11 +20,21 @@ public class SurveyController {
 
     private final SurveyService surveyService;
 
-    @PostMapping("/survey")
+    @PostMapping("/surveys")
     public CustomResponse createSurvey(@SessionUser AuthUser authUser, @RequestBody SurveyRequest surveyRequest) {
         surveyService.createSurvey(authUser.getEmail(),surveyRequest);
         return CustomResponse.success("Survey created successfully");
     }
+    @GetMapping("/surveys/all")
+    public CustomResponse getSurveysForAll(@SessionUser AuthUser authUser,Pageable pageable) {
+        Page<SurveyResponse> surveyResponsePage = surveyService.getSurveysForAll(authUser.getEmail(),pageable);
+        return CustomResponse.success(surveyResponsePage);
+    }
 
+    @GetMapping("/surveys")
+    public CustomResponse getSurveysForUser(@SessionUser AuthUser authUser, Pageable pageable) {
+        Page<SurveyResponse> surveyResponsePage = surveyService.getSurveysForUser(authUser.getEmail(),pageable);
+        return CustomResponse.success(surveyResponsePage);
+    }
 
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/ChoiceQuestionResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/ChoiceQuestionResponse.java
@@ -1,0 +1,27 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.pnu.sursim.domain.survey.entity.QuestionType;
+import com.pnu.sursim.domain.survey.entity.RequiredOption;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@SuperBuilder
+public class ChoiceQuestionResponse extends QuestionResponse {
+    protected List<OptionResponse> optionResponses;
+
+
+    public ChoiceQuestionResponse(Long id, int index, String text, QuestionType questionType, RequiredOption requiredOption, List<OptionResponse> optionResponses) {
+        super(id, index, text, questionType, requiredOption);
+        this.optionResponses = optionResponses;
+    }
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/ChoiceResponseRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/ChoiceResponseRequest.java
@@ -1,0 +1,5 @@
+package com.pnu.sursim.domain.survey.dto;
+
+public record ChoiceResponseRequest(int number,
+                                    String text) {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/ChoiceResponseRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/ChoiceResponseRequest.java
@@ -1,5 +1,0 @@
-package com.pnu.sursim.domain.survey.dto;
-
-public record ChoiceResponseRequest(int number,
-                                    String text) {
-}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/ConsentInfoRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/ConsentInfoRequest.java
@@ -1,0 +1,11 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ConsentInfoRequest(String collectionPurpose,
+                                 String collectedData,
+                                 String retentionPeriod,
+                                 String contactInfo) {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/ConsentInfoResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/ConsentInfoResponse.java
@@ -1,0 +1,11 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ConsentInfoResponse(String collectionPurpose,
+                                  String collectedData,
+                                  String retentionPeriod,
+                                  String contactInfo) {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/OptionResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/OptionResponse.java
@@ -4,5 +4,5 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record OptionResponse(Long id, int number,String text){
+public record OptionResponse(Long id, int index, String text){
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/OptionResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/OptionResponse.java
@@ -1,0 +1,8 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record OptionResponse(Long id, int number,String text){
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionOptionRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionOptionRequest.java
@@ -1,5 +1,5 @@
 package com.pnu.sursim.domain.survey.dto;
 
-public record QuestionOptionRequest(int number,
+public record QuestionOptionRequest(int index,
                                     String text) {
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionOptionRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionOptionRequest.java
@@ -1,0 +1,5 @@
+package com.pnu.sursim.domain.survey.dto;
+
+public record QuestionOptionRequest(int number,
+                                    String text) {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionRequest.java
@@ -3,11 +3,18 @@ package com.pnu.sursim.domain.survey.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.pnu.sursim.domain.survey.entity.QuestionType;
+import com.pnu.sursim.domain.survey.entity.RequiredOption;
 
 import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record QuestionRequest(int number,
-                              QuestionType questionType,
-                              List<ChoiceResponseRequest> choiceResponseRequests) {
+public record QuestionRequest(int number,       //문항 번호
+                              String text,      //문항 질문
+                              QuestionType questionType, //문항타입
+                              RequiredOption requiredOption,    //필수여부
+                              List<QuestionOptionRequest> questionOption,
+                              SemanticOptionRequest semanticOption
+) {
+
+
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionRequest.java
@@ -1,0 +1,13 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.pnu.sursim.domain.survey.entity.QuestionType;
+
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record QuestionRequest(int number,
+                              QuestionType questionType,
+                              List<ChoiceResponseRequest> choiceResponseRequests) {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionRequest.java
@@ -8,7 +8,7 @@ import com.pnu.sursim.domain.survey.entity.RequiredOption;
 import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record QuestionRequest(int number,       //문항 번호
+public record QuestionRequest(int index,       //문항 번호
                               String text,      //문항 질문
                               QuestionType questionType, //문항타입
                               RequiredOption requiredOption,    //필수여부

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/QuestionResponse.java
@@ -1,0 +1,32 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.pnu.sursim.domain.survey.entity.QuestionType;
+import com.pnu.sursim.domain.survey.entity.RequiredOption;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@SuperBuilder
+public class QuestionResponse {
+    protected Long id;
+    protected int index;                       //문항 번호
+    protected String text;                      //문항 질문
+    protected QuestionType questionType;        //문항타입
+    protected RequiredOption requiredOption;    //필수여부
+
+    public QuestionResponse(Long id, int index, String text, QuestionType questionType, RequiredOption requiredOption) {
+        this.id = id;
+        this.index = index;
+        this.text = text;
+        this.questionType = questionType;
+        this.requiredOption = requiredOption;
+    }
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/SemanticOptionRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/SemanticOptionRequest.java
@@ -1,0 +1,9 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SemanticOptionRequest(String leftEnd,
+                             String rightEnd) {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/SemanticOptionResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/SemanticOptionResponse.java
@@ -1,0 +1,9 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SemanticOptionResponse(String leftEnd,
+                                    String rightEnd) {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/SemanticQuestionResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/SemanticQuestionResponse.java
@@ -1,0 +1,24 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.pnu.sursim.domain.survey.entity.QuestionType;
+import com.pnu.sursim.domain.survey.entity.RequiredOption;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@SuperBuilder
+public class SemanticQuestionResponse extends QuestionResponse{
+    protected SemanticOptionResponse semanticOption;
+
+    public SemanticQuestionResponse(Long id, int index, String text, QuestionType questionType, RequiredOption requiredOption, SemanticOptionResponse semanticOption) {
+        super(id, index, text, questionType, requiredOption);
+        this.semanticOption = semanticOption;
+    }
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyRequest.java
@@ -1,0 +1,17 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.pnu.sursim.domain.survey.entity.PublicAccess;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SurveyRequest(
+        String title,
+        LocalDate dueDate,
+        LocalDate startDate,
+        PublicAccess publicAccess,
+        List<QuestionRequest> questionRequestList) {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyRequest.java
@@ -13,5 +13,6 @@ public record SurveyRequest(
         LocalDate dueDate,
         LocalDate startDate,
         PublicAccess publicAccess,
-        List<QuestionRequest> questionRequestList) {
+        int points,
+        List<QuestionRequest> questionList) {
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyRequest.java
@@ -18,5 +18,6 @@ public record SurveyRequest(
         PublicAccess publicAccess,
         Gender gender,
         int points,
-        List<QuestionRequest> questionList) {
+        List<QuestionRequest> questionList,
+        ConsentInfoRequest consentInfo) {
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyRequest.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyRequest.java
@@ -3,6 +3,7 @@ package com.pnu.sursim.domain.survey.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.pnu.sursim.domain.survey.entity.PublicAccess;
+import com.pnu.sursim.domain.user.entity.Gender;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -10,9 +11,12 @@ import java.util.List;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record SurveyRequest(
         String title,
-        LocalDate dueDate,
         LocalDate startDate,
+        LocalDate dueDate,
+        Integer minAge,
+        Integer maxAge,
         PublicAccess publicAccess,
+        Gender gender,
         int points,
         List<QuestionRequest> questionList) {
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyResponse.java
@@ -20,6 +20,7 @@ public record SurveyResponse(String title,
                              Gender gender,
                              int timeRequired,
                              int points,
-                             List<QuestionResponse> questionList) {
+                             List<QuestionResponse> questionList,
+                             ConsentInfoResponse consentInfo) {
 
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyResponse.java
@@ -2,7 +2,9 @@ package com.pnu.sursim.domain.survey.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.pnu.sursim.domain.survey.entity.AgeGroup;
 import com.pnu.sursim.domain.survey.entity.PublicAccess;
+import com.pnu.sursim.domain.user.entity.Gender;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -11,16 +13,13 @@ import java.util.List;
 public record SurveyResponse(String title,
                              LocalDate startDate,
                              LocalDate dueDate,
+                             AgeGroup ageGroup,
+                             Integer minAge,
+                             Integer maxAge,
                              PublicAccess publicAccess,
+                             Gender gender,
+                             int timeRequired,
                              int points,
                              List<QuestionResponse> questionList) {
 
-    public SurveyResponse(String title, LocalDate startDate, LocalDate dueDate, PublicAccess publicAccess, int points, List<QuestionResponse> questionList) {
-        this.title = title;
-        this.startDate = startDate;
-        this.dueDate = dueDate;
-        this.publicAccess = publicAccess;
-        this.points = points;
-        this.questionList = questionList;
-    }
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/dto/SurveyResponse.java
@@ -1,0 +1,26 @@
+package com.pnu.sursim.domain.survey.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.pnu.sursim.domain.survey.entity.PublicAccess;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record SurveyResponse(String title,
+                             LocalDate startDate,
+                             LocalDate dueDate,
+                             PublicAccess publicAccess,
+                             int points,
+                             List<QuestionResponse> questionList) {
+
+    public SurveyResponse(String title, LocalDate startDate, LocalDate dueDate, PublicAccess publicAccess, int points, List<QuestionResponse> questionList) {
+        this.title = title;
+        this.startDate = startDate;
+        this.dueDate = dueDate;
+        this.publicAccess = publicAccess;
+        this.points = points;
+        this.questionList = questionList;
+    }
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/AgeGroup.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/AgeGroup.java
@@ -1,0 +1,6 @@
+package com.pnu.sursim.domain.survey.entity;
+
+public enum AgeGroup {
+    SPECIFIC,
+    ALL
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/ChoiceResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/ChoiceResponse.java
@@ -1,0 +1,4 @@
+package com.pnu.sursim.domain.survey.entity;
+
+public class ChoiceResponse {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/ChoiceResponse.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/ChoiceResponse.java
@@ -1,4 +1,0 @@
-package com.pnu.sursim.domain.survey.entity;
-
-public class ChoiceResponse {
-}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/PublicAccess.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/PublicAccess.java
@@ -1,0 +1,6 @@
+package com.pnu.sursim.domain.survey.entity;
+
+public enum PublicAccess {
+    SHARED,   // 공유됨
+    PRIVATE   // 비공유
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/Question.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/Question.java
@@ -14,10 +14,13 @@ public class Question {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Enumerated(EnumType.STRING)
-    private QuestionType questionType;
+    //지금 문항번호
+    private int index;
 
     private String text;
+
+    @Enumerated(EnumType.STRING)
+    private QuestionType questionType;
 
     @Enumerated(EnumType.STRING)
     private RequiredOption requiredOption;
@@ -26,7 +29,6 @@ public class Question {
     @JoinColumn(name = "survey_id")
     private Survey survey;
 
-    private int index;
 
     @Builder
     public Question(QuestionType questionType, int index, String text, RequiredOption requiredOption, Survey survey) {

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/Question.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/Question.java
@@ -1,0 +1,39 @@
+package com.pnu.sursim.domain.survey.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Question {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private QuestionType questionType;
+
+    private String text;
+
+    @Enumerated(EnumType.STRING)
+    private RequiredOption requiredOption;
+
+    @ManyToOne
+    @JoinColumn(name = "survey_id")
+    private Survey survey;
+
+    private int index;
+
+    @Builder
+    public Question(QuestionType questionType, int index, String text, RequiredOption requiredOption, Survey survey) {
+        this.questionType = questionType;
+        this.index = index;
+        this.text = text;
+        this.requiredOption = requiredOption;
+        this.survey = survey;
+    }
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/QuestionOption.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/QuestionOption.java
@@ -1,0 +1,34 @@
+package com.pnu.sursim.domain.survey.entity;
+
+import com.pnu.sursim.domain.survey.entity.Question;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionOption {   //객관식응답(단일선택)
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int indexOfCurrentResponse;
+
+    private String text;
+
+
+    @ManyToOne
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @Builder
+    public QuestionOption(int indexOfCurrentResponse, String text, Question question) {
+        this.indexOfCurrentResponse = indexOfCurrentResponse;
+        this.text = text;
+        this.question = question;
+    }
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/QuestionOption.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/QuestionOption.java
@@ -16,7 +16,7 @@ public class QuestionOption {   //객관식응답(단일선택)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private int indexOfCurrentResponse;
+    private int index;
 
     private String text;
 
@@ -26,8 +26,8 @@ public class QuestionOption {   //객관식응답(단일선택)
     private Question question;
 
     @Builder
-    public QuestionOption(int indexOfCurrentResponse, String text, Question question) {
-        this.indexOfCurrentResponse = indexOfCurrentResponse;
+    public QuestionOption(int index, String text, Question question) {
+        this.index = index;
         this.text = text;
         this.question = question;
     }

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/QuestionType.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/QuestionType.java
@@ -1,19 +1,26 @@
 package com.pnu.sursim.domain.survey.entity;
 
 public enum QuestionType {
-    CHECK_CHOICE("체크박스"),
-    SEMANTIC_RATINGS("의미분별척도"),
-    LIKERT_SCORES("리커트척도"),
-    MULTIPLE_CHOICE("객관식"),
-    NUMERIC_RESPONSE("숫자응답"),
-    PHONE_NUMBER("전화번호");
+    CHECK_CHOICE("체크박스", 1), // 1분
+    SEMANTIC_RATINGS("의미분별척도", 2), // 2분
+    LIKERT_SCORES("리커트척도", 2), // 2분
+    MULTIPLE_CHOICE("객관식", 1), // 1분
+    NUMERIC_RESPONSE("숫자응답", 1), // 1분
+    PHONE_NUMBER("전화번호", 1), // 1분
+    SUBJECTIVE("주관식", 3), // 3분
+    DESCRIPTIVE("서술형", 5); // 5분
 
     private String description;
+    private final int timeTaken;
 
-    QuestionType(String description) {
+    QuestionType(String description, int minutes) {
         this.description = description;
+        this.timeTaken = minutes;
     }
 
+    public int getTimeTaken() {
+        return timeTaken;
+    }
     public String getDescription() {
         return description;
     }

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/QuestionType.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/QuestionType.java
@@ -1,0 +1,20 @@
+package com.pnu.sursim.domain.survey.entity;
+
+public enum QuestionType {
+    CHECK_CHOICE("체크박스"),
+    SEMANTIC_RATINGS("의미분별척도"),
+    LIKERT_SCORES("리커트척도"),
+    MULTIPLE_CHOICE("객관식"),
+    NUMERIC_RESPONSE("숫자응답"),
+    PHONE_NUMBER("전화번호");
+
+    private String description;
+
+    QuestionType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/RequiredOption.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/RequiredOption.java
@@ -1,0 +1,6 @@
+package com.pnu.sursim.domain.survey.entity;
+
+public enum RequiredOption {
+    REQUIRED, //필수
+    OPTIONAL; //선택
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/SemanticOption.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/SemanticOption.java
@@ -1,0 +1,32 @@
+package com.pnu.sursim.domain.survey.entity;
+
+import com.pnu.sursim.domain.survey.entity.Question;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SemanticOption {   //의미 분별 척도 응답의 정보
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String leftEnd;
+    private String rightEnd;
+
+    @OneToOne
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @Builder
+    public SemanticOption(String leftEnd, String rightEnd, Question question) {
+        this.leftEnd = leftEnd;
+        this.rightEnd = rightEnd;
+        this.question = question;
+    }
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
@@ -52,6 +52,9 @@ public class Survey {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    @Enumerated(EnumType.STRING)
+    AgeGroup ageGroup;
+
     @Builder.Default
     @OneToMany(mappedBy = "survey")
     private List<Question> questions= new ArrayList<>();

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
@@ -55,8 +55,4 @@ public class Survey {
     @Enumerated(EnumType.STRING)
     AgeGroup ageGroup;
 
-    @Builder.Default
-    @OneToMany(mappedBy = "survey")
-    private List<Question> questions= new ArrayList<>();
-
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
@@ -55,4 +55,8 @@ public class Survey {
     @Enumerated(EnumType.STRING)
     AgeGroup ageGroup;
 
+    private String collectionPurpose;   // 수집 목적
+    private String collectedData;       // 수집 정보
+    private String retentionPeriod;     // 보유 기간
+    private String contactInfo;         // 가능한 연락처
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
@@ -6,16 +6,17 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.*;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+@Builder
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Survey {
 
     @Id
@@ -25,6 +26,9 @@ public class Survey {
     @ManyToOne
     @JoinColumn(name = "users_id")
     private User creator;
+
+    //설문 제목
+    private String title;
 
     //시작날짜
     private LocalDate startDate;
@@ -48,16 +52,8 @@ public class Survey {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    @Builder
-    public Survey(User creator, LocalDate startDate, LocalDate dueDate, int minAge, int maxAge, PublicAccess publicAccess, int timeRequired, int points, Gender gender) {
-        this.creator = creator;
-        this.startDate = startDate;
-        this.dueDate = dueDate;
-        this.minAge = minAge;
-        this.maxAge = maxAge;
-        this.publicAccess = publicAccess;
-        this.timeRequired = timeRequired;
-        this.points = points;
-        this.gender = gender;
-    }
+    @Builder.Default
+    @OneToMany(mappedBy = "survey")
+    private List<Question> questions= new ArrayList<>();
+
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
@@ -1,0 +1,49 @@
+package com.pnu.sursim.domain.survey.entity;
+
+import com.pnu.sursim.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Survey {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "users_id")
+    private User creator;
+
+    private LocalDate dueDate;
+
+    private LocalDate startDate;
+
+    @Enumerated(EnumType.STRING)
+    private PublicAccess publicAccess;
+
+    private int timeRequired;
+
+    private int points;
+
+
+    @Builder
+    public Survey(User creator, LocalDate dueDate, LocalDate startDate, PublicAccess publicAccess, int timeRequired, int points) {
+        this.creator = creator;
+        this.dueDate = dueDate;
+        this.startDate = startDate;
+        this.publicAccess = publicAccess;
+        this.timeRequired = timeRequired;
+        this.points = points;
+    }
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/entity/Survey.java
@@ -1,5 +1,6 @@
 package com.pnu.sursim.domain.survey.entity;
 
+import com.pnu.sursim.domain.user.entity.Gender;
 import com.pnu.sursim.domain.user.entity.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.*;
@@ -25,9 +26,17 @@ public class Survey {
     @JoinColumn(name = "users_id")
     private User creator;
 
+    //시작날짜
+    private LocalDate startDate;
+
+    //마감날짜
     private LocalDate dueDate;
 
-    private LocalDate startDate;
+    //가능한 나이 시작
+    private int minAge;
+
+    //가능한 나이 끝
+    private int maxAge;
 
     @Enumerated(EnumType.STRING)
     private PublicAccess publicAccess;
@@ -36,14 +45,19 @@ public class Survey {
 
     private int points;
 
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
 
     @Builder
-    public Survey(User creator, LocalDate dueDate, LocalDate startDate, PublicAccess publicAccess, int timeRequired, int points) {
+    public Survey(User creator, LocalDate startDate, LocalDate dueDate, int minAge, int maxAge, PublicAccess publicAccess, int timeRequired, int points, Gender gender) {
         this.creator = creator;
-        this.dueDate = dueDate;
         this.startDate = startDate;
+        this.dueDate = dueDate;
+        this.minAge = minAge;
+        this.maxAge = maxAge;
         this.publicAccess = publicAccess;
         this.timeRequired = timeRequired;
         this.points = points;
+        this.gender = gender;
     }
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/repository/QuestionOptionRepository.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/repository/QuestionOptionRepository.java
@@ -3,5 +3,9 @@ package com.pnu.sursim.domain.survey.repository;
 import com.pnu.sursim.domain.survey.entity.QuestionOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuestionOptionRepository extends JpaRepository<QuestionOption, Long> {
+
+    List<QuestionOption> findAllByQuestionId(Long id);
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/repository/QuestionOptionRepository.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/repository/QuestionOptionRepository.java
@@ -1,0 +1,7 @@
+package com.pnu.sursim.domain.survey.repository;
+
+import com.pnu.sursim.domain.survey.entity.QuestionOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionOptionRepository extends JpaRepository<QuestionOption, Long> {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/repository/QuestionOptionRepository.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/repository/QuestionOptionRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface QuestionOptionRepository extends JpaRepository<QuestionOption, Long> {
 
-    List<QuestionOption> findAllByQuestionId(Long id);
+    List<QuestionOption> findAllByQuestionIdOrderByIndexAsc(Long id);
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/repository/QuestionRepository.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/repository/QuestionRepository.java
@@ -3,5 +3,9 @@ package com.pnu.sursim.domain.survey.repository;
 import com.pnu.sursim.domain.survey.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    List<Question> findAllBySurveyIdOrderByIndexAsc(Long id);
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/repository/QuestionRepository.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/repository/QuestionRepository.java
@@ -1,0 +1,7 @@
+package com.pnu.sursim.domain.survey.repository;
+
+import com.pnu.sursim.domain.survey.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/repository/SemanticOptionRepository.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/repository/SemanticOptionRepository.java
@@ -1,0 +1,7 @@
+package com.pnu.sursim.domain.survey.repository;
+
+import com.pnu.sursim.domain.survey.entity.SemanticOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SemanticOptionRepository extends JpaRepository<SemanticOption, Long> {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/repository/SemanticOptionRepository.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/repository/SemanticOptionRepository.java
@@ -3,5 +3,8 @@ package com.pnu.sursim.domain.survey.repository;
 import com.pnu.sursim.domain.survey.entity.SemanticOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SemanticOptionRepository extends JpaRepository<SemanticOption, Long> {
+    Optional<SemanticOption> findByQuestionId(Long id);
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/repository/SurveyRepository.java
@@ -1,7 +1,19 @@
 package com.pnu.sursim.domain.survey.repository;
 
 import com.pnu.sursim.domain.survey.entity.Survey;
+import com.pnu.sursim.domain.user.entity.Gender;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
 
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
+
+    @Query("SELECT s FROM Survey s WHERE " +
+            "(YEAR(CURRENT_DATE) - YEAR(:birthDate)) >= s.minAge AND " +
+            "(YEAR(CURRENT_DATE) - YEAR(:birthDate)) <= s.maxAge AND " +
+            "(s.gender = :gender OR s.gender = com.pnu.sursim.domain.user.entity.Gender.NONE)")
+    Page<Survey> findAllByAgeAndGender(LocalDate birthDate, Gender gender, Pageable pageable);
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/repository/SurveyRepository.java
@@ -1,0 +1,7 @@
+package com.pnu.sursim.domain.survey.repository;
+
+import com.pnu.sursim.domain.survey.entity.Survey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/service/SurveyService.java
@@ -38,7 +38,7 @@ public class SurveyService {
         Survey savedSurvey = surveyRepository.save(SurveyFactory.makeSurvey(surveyRequest, creator));
 
         //문항을 만드는 부분
-        List<Question> questions = surveyRequest.questionRequestList().stream()
+        List<Question> questions = surveyRequest.questionList().stream()
                 .map(questionRequest -> {
                     // Question 객체 생성 & 데이터베이스에 Question 저장
                     Question savedQuestion = questionRepository.save(SurveyFactory.makeQuestion(questionRequest, savedSurvey));
@@ -53,7 +53,7 @@ public class SurveyService {
 
                     if (savedQuestion.getQuestionType() == QuestionType.LIKERT_SCORES) {
                         // 의미 분별 척도인 경우
-                        SemanticOption semanticOption = semanticOptionRepository.save(SurveyFactory.makeSemantic(questionRequest.semanticOptionRequest(),savedQuestion));
+                        SemanticOption semanticOption = semanticOptionRepository.save(SurveyFactory.makeSemantic(questionRequest.semanticOption(),savedQuestion));
 
                     }
 

--- a/src/main/java/com/pnu/sursim/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/service/SurveyService.java
@@ -1,0 +1,71 @@
+package com.pnu.sursim.domain.survey.service;
+
+import com.pnu.sursim.domain.survey.dto.QuestionRequest;
+import com.pnu.sursim.domain.survey.dto.SurveyRequest;
+import com.pnu.sursim.domain.survey.entity.*;
+import com.pnu.sursim.domain.survey.repository.QuestionOptionRepository;
+import com.pnu.sursim.domain.survey.repository.QuestionRepository;
+import com.pnu.sursim.domain.survey.repository.SemanticOptionRepository;
+import com.pnu.sursim.domain.survey.repository.SurveyRepository;
+import com.pnu.sursim.domain.survey.util.SurveyFactory;
+import com.pnu.sursim.domain.user.entity.User;
+import com.pnu.sursim.domain.user.repository.UserRepository;
+import com.pnu.sursim.global.exception.CustomException;
+import com.pnu.sursim.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class SurveyService {
+
+    private final UserRepository userRepository;
+    private final SurveyRepository surveyRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final SemanticOptionRepository semanticOptionRepository;
+
+    @Transactional
+    public void createSurvey(String email, SurveyRequest surveyRequest) {
+        User creator = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_ERROR));
+
+        Survey savedSurvey = surveyRepository.save(SurveyFactory.makeSurvey(surveyRequest, creator));
+
+        //문항을 만드는 부분
+        List<Question> questions = surveyRequest.questionRequestList().stream()
+                .map(questionRequest -> {
+                    // Question 객체 생성 & 데이터베이스에 Question 저장
+                    Question savedQuestion = questionRepository.save(SurveyFactory.makeQuestion(questionRequest, savedSurvey));
+
+                    //응답옵션이 필요한 경우에 응답만들기
+                    if ((savedQuestion.getQuestionType() == QuestionType.CHECK_CHOICE) || (savedQuestion.getQuestionType() == QuestionType.MULTIPLE_CHOICE)) {
+                        // 체크박스거나 객관식인 경우
+                        List<QuestionOption> questionOptions = questionRequest.questionOption().stream()
+                                .map(questionOptionRequest -> questionOptionRepository.save(SurveyFactory.makeOption(questionOptionRequest, savedQuestion)))
+                                .collect(Collectors.toList());
+                    }
+
+                    if (savedQuestion.getQuestionType() == QuestionType.LIKERT_SCORES) {
+                        // 의미 분별 척도인 경우
+                        SemanticOption semanticOption = semanticOptionRepository.save(SurveyFactory.makeSemantic(questionRequest.semanticOptionRequest(),savedQuestion));
+
+                    }
+
+                    // 수정된 Question 반환
+                    return savedQuestion;
+                })
+                .collect(Collectors.toList());
+
+    }
+
+    private void createQuestion(QuestionType questionType, QuestionRequest question) {
+    }
+
+
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/service/SurveyService.java
@@ -73,12 +73,12 @@ public class SurveyService {
         Page<SurveyResponse> surveyResponsePage = new PageImpl<>(surveys.getContent().stream()
                 .map(survey -> {
                     //서베이의 문항을 적절하게 변환하는 로직
-                    List<QuestionResponse> questionResponses = survey.getQuestions().stream()
-
+                    List<QuestionResponse> questionResponses = questionRepository.findAllBySurveyIdOrderByIndexAsc(survey.getId())
+                            .stream()
                             .map(question -> {
                                 //문항의 타입이 단일/체크 경우 변경
                                 if ((question.getQuestionType() == QuestionType.CHECK_CHOICE) || (question.getQuestionType() == QuestionType.MULTIPLE_CHOICE)) {
-                                    List<QuestionOption> questionOptions = questionOptionRepository.findAllByQuestionId(question.getId());
+                                    List<QuestionOption> questionOptions = questionOptionRepository.findAllByQuestionIdOrderByIndexAsc(question.getId());
                                     if (questionOptions.isEmpty()) {
                                         throw new CustomException(ErrorCode.INCORRECT_CHOICE_QUESTION);
                                     }

--- a/src/main/java/com/pnu/sursim/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/service/SurveyService.java
@@ -55,7 +55,7 @@ public class SurveyService {
                                 .collect(Collectors.toList());
                     }
 
-                    if (savedQuestion.getQuestionType() == QuestionType.LIKERT_SCORES) {
+                    if (savedQuestion.getQuestionType() == QuestionType.SEMANTIC_RATINGS) {
                         // 의미 분별 척도인 경우
                         SemanticOption semanticOption = semanticOptionRepository.save(SurveyFactory.makeSemantic(questionRequest.semanticOption(), savedQuestion));
 
@@ -86,7 +86,7 @@ public class SurveyService {
                                 }
 
                                 //문항 타입이 의미판별인 경우 변경
-                                if (question.getQuestionType() == QuestionType.LIKERT_SCORES) {
+                                if (question.getQuestionType() == QuestionType.SEMANTIC_RATINGS) {
                                     SemanticOption semanticOption = semanticOptionRepository.findByQuestionId(question.getId())
                                             .orElseThrow(() -> new CustomException(ErrorCode.INCORRECT_SEMANTIC_QUESTIONS));
                                     return SurveyFactory.makeSemanticQuestionResponse(question, semanticOption);

--- a/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
@@ -1,10 +1,7 @@
 package com.pnu.sursim.domain.survey.util;
 
 import com.pnu.sursim.domain.survey.dto.*;
-import com.pnu.sursim.domain.survey.entity.Question;
-import com.pnu.sursim.domain.survey.entity.QuestionOption;
-import com.pnu.sursim.domain.survey.entity.SemanticOption;
-import com.pnu.sursim.domain.survey.entity.Survey;
+import com.pnu.sursim.domain.survey.entity.*;
 import com.pnu.sursim.domain.user.entity.User;
 
 import java.util.List;
@@ -16,8 +13,14 @@ import static com.pnu.sursim.domain.survey.util.SurveyRequiredTimeCalculator.cal
 public class SurveyFactory {
 
     public static Survey makeSurvey(SurveyRequest surveyRequest, User creator) {
+        AgeGroup ageGroup = AgeGroup.SPECIFIC;
+
+        if (surveyRequest.minAge()==null && surveyRequest.maxAge() ==null){
+            ageGroup = AgeGroup.ALL;
+        }
+
         int minAge = Optional.ofNullable(surveyRequest.minAge()).orElse(0);
-        int maxAge = Optional.ofNullable(surveyRequest.minAge()).orElse(Integer.MAX_VALUE);
+        int maxAge = Optional.ofNullable(surveyRequest.maxAge()).orElse(Integer.MAX_VALUE);
 
         return Survey.builder()
                 .title(surveyRequest.title())
@@ -30,6 +33,7 @@ public class SurveyFactory {
                 .minAge(minAge)
                 .maxAge(maxAge)
                 .gender(surveyRequest.gender())
+                .ageGroup(ageGroup)
                 .build();
     }
 
@@ -60,7 +64,18 @@ public class SurveyFactory {
     }
 
     public static SurveyResponse makeSurveyResponse(Survey survey, List<QuestionResponse> questionResponses ) {
-        return new SurveyResponse(survey.getTitle(), survey.getStartDate(), survey.getDueDate(), survey.getPublicAccess(), survey.getPoints(),questionResponses);
+        return new SurveyResponse(
+                survey.getTitle(),
+                survey.getStartDate(),
+                survey.getDueDate(),
+                survey.getAgeGroup(),
+                survey.getMinAge(),
+                survey.getMaxAge(),
+                survey.getPublicAccess(),
+                survey.getGender(),
+                survey.getTimeRequired(),
+                survey.getPoints(),
+                questionResponses);
     }
 
 

--- a/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
@@ -34,6 +34,10 @@ public class SurveyFactory {
                 .maxAge(maxAge)
                 .gender(surveyRequest.gender())
                 .ageGroup(ageGroup)
+                .collectionPurpose(surveyRequest.consentInfoRequest().collectionPurpose())
+                .collectedData(surveyRequest.consentInfoRequest().collectedData())
+                .retentionPeriod(surveyRequest.consentInfoRequest().retentionPeriod())
+                .contactInfo(surveyRequest.consentInfoRequest().contactInfo())
                 .build();
     }
 
@@ -75,7 +79,8 @@ public class SurveyFactory {
                 survey.getGender(),
                 survey.getTimeRequired(),
                 survey.getPoints(),
-                questionResponses);
+                questionResponses,
+                new ConsentInfoResponse(survey.getCollectionPurpose(), survey.getCollectedData(), survey.getRetentionPeriod(), survey.getContactInfo()));
     }
 
 

--- a/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
@@ -1,0 +1,54 @@
+package com.pnu.sursim.domain.survey.util;
+
+import com.pnu.sursim.domain.survey.dto.QuestionOptionRequest;
+import com.pnu.sursim.domain.survey.dto.QuestionRequest;
+import com.pnu.sursim.domain.survey.dto.SemanticOptionRequest;
+import com.pnu.sursim.domain.survey.dto.SurveyRequest;
+import com.pnu.sursim.domain.survey.entity.Question;
+import com.pnu.sursim.domain.survey.entity.QuestionOption;
+import com.pnu.sursim.domain.survey.entity.SemanticOption;
+import com.pnu.sursim.domain.survey.entity.Survey;
+import com.pnu.sursim.domain.user.entity.User;
+
+import static com.pnu.sursim.domain.survey.util.SurveyRequiredTimeCalculator.calculateRequiredTime;
+
+public class SurveyFactory {
+
+    public static Survey makeSurvey(SurveyRequest surveyRequest, User creator) {
+        return Survey.builder()
+                .creator(creator)
+                .startDate(surveyRequest.startDate())
+                .dueDate(surveyRequest.dueDate())
+                .publicAccess(surveyRequest.publicAccess())
+                .points(surveyRequest.points())
+                .timeRequired(calculateRequiredTime(surveyRequest))
+                .build();
+    }
+
+    public static Question makeQuestion(QuestionRequest questionRequest, Survey survey) {
+        return Question.builder()
+                .text(questionRequest.text())
+                .questionType(questionRequest.questionType())
+                .requiredOption(questionRequest.requiredOption())
+                .index(questionRequest.number())
+                .survey(survey)
+                .build();
+    }
+
+    public static QuestionOption makeOption(QuestionOptionRequest questionOptionRequest, Question question) {
+        return QuestionOption.builder()
+                .indexOfCurrentResponse(questionOptionRequest.number())
+                .text(questionOptionRequest.text())
+                .question(question)
+                .build();
+    }
+
+    public static SemanticOption makeSemantic(SemanticOptionRequest semanticOptionRequest, Question question) {
+        return SemanticOption.builder()
+                .leftEnd(semanticOptionRequest.leftEnd())
+                .rightEnd(semanticOptionRequest.rightEnd())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
@@ -1,16 +1,15 @@
 package com.pnu.sursim.domain.survey.util;
 
-import com.pnu.sursim.domain.survey.dto.QuestionOptionRequest;
-import com.pnu.sursim.domain.survey.dto.QuestionRequest;
-import com.pnu.sursim.domain.survey.dto.SemanticOptionRequest;
-import com.pnu.sursim.domain.survey.dto.SurveyRequest;
+import com.pnu.sursim.domain.survey.dto.*;
 import com.pnu.sursim.domain.survey.entity.Question;
 import com.pnu.sursim.domain.survey.entity.QuestionOption;
 import com.pnu.sursim.domain.survey.entity.SemanticOption;
 import com.pnu.sursim.domain.survey.entity.Survey;
 import com.pnu.sursim.domain.user.entity.User;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.pnu.sursim.domain.survey.util.SurveyRequiredTimeCalculator.calculateRequiredTime;
 
@@ -21,6 +20,7 @@ public class SurveyFactory {
         int maxAge = Optional.ofNullable(surveyRequest.minAge()).orElse(Integer.MAX_VALUE);
 
         return Survey.builder()
+                .title(surveyRequest.title())
                 .creator(creator)
                 .startDate(surveyRequest.startDate())
                 .dueDate(surveyRequest.dueDate())
@@ -45,7 +45,7 @@ public class SurveyFactory {
 
     public static QuestionOption makeOption(QuestionOptionRequest questionOptionRequest, Question question) {
         return QuestionOption.builder()
-                .indexOfCurrentResponse(questionOptionRequest.number())
+                .index(questionOptionRequest.number())
                 .text(questionOptionRequest.text())
                 .question(question)
                 .build();
@@ -58,5 +58,42 @@ public class SurveyFactory {
                 .build();
     }
 
+    public static SurveyResponse makeSurveyResponse(Survey survey, List<QuestionResponse> questionResponses ) {
+        return new SurveyResponse(survey.getTitle(), survey.getStartDate(), survey.getDueDate(), survey.getPublicAccess(), survey.getPoints(),questionResponses);
+    }
 
+
+    public static ChoiceQuestionResponse makeChoiceQuestionResponse(Question question, List<QuestionOption> questionOptions) {
+        return ChoiceQuestionResponse.builder()
+                .optionResponses(questionOptions.stream()
+                        .map(questionOption -> new OptionResponse(questionOption.getId(),questionOption.getIndex(),questionOption.getText()))
+                        .collect(Collectors.toList()))
+                .id(question.getId())
+                .index(question.getIndex())
+                .text(question.getText())
+                .questionType(question.getQuestionType())
+                .requiredOption(question.getRequiredOption())
+                .build();
+    }
+
+    public static SemanticQuestionResponse makeSemanticQuestionResponse(Question question, SemanticOption semanticOption) {
+        return SemanticQuestionResponse.builder()
+                .semanticOption(new SemanticOptionResponse(semanticOption.getLeftEnd(), semanticOption.getRightEnd()))
+                .id(question.getId())
+                .index(question.getIndex())
+                .text(question.getText())
+                .questionType(question.getQuestionType())
+                .requiredOption(question.getRequiredOption())
+                .build();
+    }
+
+    public static QuestionResponse makeQuestionResponse(Question question) {
+        return QuestionResponse.builder()
+                .id(question.getId())
+                .index(question.getIndex())
+                .text(question.getText())
+                .questionType(question.getQuestionType())
+                .requiredOption(question.getRequiredOption())
+                .build();
+    }
 }

--- a/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
@@ -42,14 +42,14 @@ public class SurveyFactory {
                 .text(questionRequest.text())
                 .questionType(questionRequest.questionType())
                 .requiredOption(questionRequest.requiredOption())
-                .index(questionRequest.number())
+                .index(questionRequest.index())
                 .survey(survey)
                 .build();
     }
 
     public static QuestionOption makeOption(QuestionOptionRequest questionOptionRequest, Question question) {
         return QuestionOption.builder()
-                .index(questionOptionRequest.number())
+                .index(questionOptionRequest.index())
                 .text(questionOptionRequest.text())
                 .question(question)
                 .build();

--- a/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
@@ -34,10 +34,10 @@ public class SurveyFactory {
                 .maxAge(maxAge)
                 .gender(surveyRequest.gender())
                 .ageGroup(ageGroup)
-                .collectionPurpose(surveyRequest.consentInfoRequest().collectionPurpose())
-                .collectedData(surveyRequest.consentInfoRequest().collectedData())
-                .retentionPeriod(surveyRequest.consentInfoRequest().retentionPeriod())
-                .contactInfo(surveyRequest.consentInfoRequest().contactInfo())
+                .collectionPurpose(surveyRequest.consentInfo().collectionPurpose())
+                .collectedData(surveyRequest.consentInfo().collectedData())
+                .retentionPeriod(surveyRequest.consentInfo().retentionPeriod())
+                .contactInfo(surveyRequest.consentInfo().contactInfo())
                 .build();
     }
 

--- a/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
@@ -55,6 +55,7 @@ public class SurveyFactory {
         return SemanticOption.builder()
                 .leftEnd(semanticOptionRequest.leftEnd())
                 .rightEnd(semanticOptionRequest.rightEnd())
+                .question(question)
                 .build();
     }
 

--- a/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/util/SurveyFactory.java
@@ -10,11 +10,16 @@ import com.pnu.sursim.domain.survey.entity.SemanticOption;
 import com.pnu.sursim.domain.survey.entity.Survey;
 import com.pnu.sursim.domain.user.entity.User;
 
+import java.util.Optional;
+
 import static com.pnu.sursim.domain.survey.util.SurveyRequiredTimeCalculator.calculateRequiredTime;
 
 public class SurveyFactory {
 
     public static Survey makeSurvey(SurveyRequest surveyRequest, User creator) {
+        int minAge = Optional.ofNullable(surveyRequest.minAge()).orElse(0);
+        int maxAge = Optional.ofNullable(surveyRequest.minAge()).orElse(Integer.MAX_VALUE);
+
         return Survey.builder()
                 .creator(creator)
                 .startDate(surveyRequest.startDate())
@@ -22,6 +27,9 @@ public class SurveyFactory {
                 .publicAccess(surveyRequest.publicAccess())
                 .points(surveyRequest.points())
                 .timeRequired(calculateRequiredTime(surveyRequest))
+                .minAge(minAge)
+                .maxAge(maxAge)
+                .gender(surveyRequest.gender())
                 .build();
     }
 

--- a/src/main/java/com/pnu/sursim/domain/survey/util/SurveyRequiredTimeCalculator.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/util/SurveyRequiredTimeCalculator.java
@@ -5,7 +5,7 @@ import com.pnu.sursim.domain.survey.dto.SurveyRequest;
 public class SurveyRequiredTimeCalculator {
 
     public static int calculateRequiredTime(SurveyRequest surveyRequest) {
-        int timeRequired = surveyRequest.questionRequestList()
+        int timeRequired = surveyRequest.questionList()
                 .stream() // 문항 리스트를 스트림으로 변환
                 .mapToInt(questionRequest -> questionRequest.questionType().getTimeTaken()) // 각 문항의 소요 시간을 정수로 매핑
                 .sum();

--- a/src/main/java/com/pnu/sursim/domain/survey/util/SurveyRequiredTimeCalculator.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/util/SurveyRequiredTimeCalculator.java
@@ -1,0 +1,14 @@
+package com.pnu.sursim.domain.survey.util;
+
+import com.pnu.sursim.domain.survey.dto.SurveyRequest;
+
+public class SurveyRequiredTimeCalculator {
+
+    public static int calculateRequiredTime(SurveyRequest surveyRequest) {
+        int timeRequired = surveyRequest.questionRequestList()
+                .stream() // 문항 리스트를 스트림으로 변환
+                .mapToInt(questionRequest -> questionRequest.questionType().getTimeTaken()) // 각 문항의 소요 시간을 정수로 매핑
+                .sum();
+        return timeRequired;
+    }
+}

--- a/src/main/java/com/pnu/sursim/domain/user/dto/KakaoFirstInfo.java
+++ b/src/main/java/com/pnu/sursim/domain/user/dto/KakaoFirstInfo.java
@@ -1,10 +1,13 @@
 package com.pnu.sursim.domain.user.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.pnu.sursim.domain.user.entity.Gender;
 import com.pnu.sursim.domain.user.entity.Region;
 
 import java.time.LocalDate;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoFirstInfo(LocalDate birthDate,
                              Gender gender,
                              Region region) {

--- a/src/main/java/com/pnu/sursim/domain/user/entity/Gender.java
+++ b/src/main/java/com/pnu/sursim/domain/user/entity/Gender.java
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Gender{
     FEMALE("여성"),
-    MALE("남성"),;
+    MALE("남성"),
+    NONE("무관");
 
     private final String koreanName;
 

--- a/src/main/java/com/pnu/sursim/global/config/WebConfig.java
+++ b/src/main/java/com/pnu/sursim/global/config/WebConfig.java
@@ -30,7 +30,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authLoginInterceptor)
-                .addPathPatterns("/api/user/**","/api/auth/kakao-first-login")
+                .addPathPatterns("/api/survey","/api/survey/**","/api/user/**","/api/auth/kakao-first-login")
                 .excludePathPatterns("/api/auth/login","/api/auth/login/**","/api/auth/join", "/api/health");
 
     }

--- a/src/main/java/com/pnu/sursim/global/config/WebConfig.java
+++ b/src/main/java/com/pnu/sursim/global/config/WebConfig.java
@@ -30,7 +30,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authLoginInterceptor)
-                .addPathPatterns("/api/survey","/api/survey/**","/api/user/**","/api/auth/kakao-first-login")
+                .addPathPatterns("/api/surveys","/api/surveys/**","/api/user/**","/api/auth/kakao-first-login")
                 .excludePathPatterns("/api/auth/login","/api/auth/login/**","/api/auth/join", "/api/health");
 
     }

--- a/src/main/java/com/pnu/sursim/global/exception/CustomException.java
+++ b/src/main/java/com/pnu/sursim/global/exception/CustomException.java
@@ -14,11 +14,6 @@ public class CustomException extends RuntimeException{
 
     }
 
-    public CustomException(Exception e) {
-        super(e.getMessage());
-        this.httpStatus = HttpStatus.BAD_REQUEST;
-
-    }
     @Override
     public String getMessage() {
         return super.getMessage();

--- a/src/main/java/com/pnu/sursim/global/exception/ErrorCode.java
+++ b/src/main/java/com/pnu/sursim/global/exception/ErrorCode.java
@@ -20,7 +20,9 @@ public enum ErrorCode {
     //회원
     USER_ERROR(HttpStatus.BAD_REQUEST,"There is no member information."),
 
-
+    //설문조사관련응답
+    INCORRECT_CHOICE_QUESTION(HttpStatus.BAD_REQUEST,"An error occurred in the CHOICE_QUESTION. This may be a wrong survey. Please contact the developer."),
+    INCORRECT_SEMANTIC_QUESTIONS(HttpStatus.BAD_REQUEST,"An error occurred in the SEMANTIC_QUESTIONS. This may be a wrong survey. Please contact the developer.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/pnu/sursim/global/response/CustomPage.java
+++ b/src/main/java/com/pnu/sursim/global/response/CustomPage.java
@@ -1,0 +1,16 @@
+package com.pnu.sursim.global.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record CustomPage(int totalPage,
+                         List<?> content) {
+
+    public CustomPage(Page<?> page) {
+        this(page.getTotalPages(), page.getContent());
+    }
+}


### PR DESCRIPTION
## 이슈번호 : #5 

### 설문조사 만들기
- 서베이의 기본 정보들 : 제목, 시작일-마감일, 공개 여부, 응답자 나이, 성별 
- 문항 별 로 생성 할 수 있음
- 수집목표, 수집정보, 보유 기관, 연락처에 대한 정보를 담았음

### 설문조사 조회
자동으로 유저에 맞춰 필터링 해서 조회
_**! 이후에 날짜 기준 정렬 전략 선택 필요**_
_**! 추가리워드 정보의 경우 반영하지 못함, S3에 이미지를 등록하면서 함께 하려고 함!! **_
