### PR TITLE
설문조사 조회 & 로그인 필요한 요청 & 에러 반환 형태 변경

### DIFF
--- a/src/main/java/com/pnu/sursim/domain/survey/controller/SurveyController.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/controller/SurveyController.java
@@ -19,8 +19,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -32,43 +30,53 @@ public class SurveyController {
     //서베이에 리워드 추가 요청
     @PostMapping("/surveys")
     public CustomResponse createSurvey(@SessionUser AuthUser authUser,
-                                    @RequestPart("survey") SurveyRequest surveyRequest,
-                                    @RequestPart(value = "reward", required = false) RewardRequest rewardRequest,
-                                    @RequestPart(value = "reward_file", required = false) MultipartFile rewardFile){
+                                       @RequestPart("survey") SurveyRequest surveyRequest,
+                                       @RequestPart(value = "reward", required = false) RewardRequest rewardRequest,
+                                       @RequestPart(value = "reward_file", required = false) MultipartFile rewardFile) {
         if ((rewardFile == null && rewardRequest != null) || (rewardFile != null && rewardRequest == null)) {
             throw new CustomException(ErrorCode.REWARD_REQUEST_INVALID);
         }
-        //둘다 있는 경우..에 넣어야하나?
-        surveyService.createSurvey(authUser.getEmail(), surveyRequest,rewardRequest, rewardFile);
+
+        surveyService.createSurvey(authUser.getEmail(), surveyRequest, rewardRequest, rewardFile);
         return CustomResponse.success("Reward registration has been successfully completed.");
     }
 
-    //모든 서베이 페이지 요청
-    @GetMapping("/surveys/all")
-    public CustomResponse getSurveyPageForAll(@SessionUser AuthUser authUser, Pageable pageable) {
-        Page<SurveyResponse> surveyResponsePage = surveyService.getSurveyPageForAll(pageable);
-        return CustomResponse.success(new CustomPage(surveyResponsePage));
-    }
-
-    //유저에 맞는 서베이 페이지 요청
+    //서베이 페이지 요청
     @GetMapping("/surveys")
-    public CustomResponse getSurveyPageForUser(@SessionUser AuthUser authUser, Pageable pageable) {
+    public CustomResponse getSurveyPage(@SessionUser(required = false) AuthUser authUser, Pageable pageable) {
+        if (authUser == null) {
+            return CustomResponse.success(new CustomPage(surveyService.getSurveyPageForAll(pageable)));
+        }
         Page<SurveyResponse> surveyResponsePage = surveyService.getSurveyPageForUser(authUser.getEmail(), pageable);
         return CustomResponse.success(new CustomPage(surveyResponsePage));
     }
 
-    //유저에 맞는 리워드 포함 서베이 페이지 요청
-    @GetMapping("/surveys/reward")
-    public CustomResponse getSurveyPageForReward(@SessionUser AuthUser authUser, Pageable pageable) {
-        Page<SurveyResponse> surveyResponsePage = surveyService.getSurveyPageForReward(authUser.getEmail(), pageable);
+    //리워드 포함 서베이 페이지 요청
+    @GetMapping("/surveys/has-reward")
+    public CustomResponse getSurveyPageHasReward(@SessionUser(required = false) AuthUser authUser, Pageable pageable) {
+        if (authUser == null) {
+            return CustomResponse.success(new CustomPage(surveyService.getSurveyPageHasRewardForAll(pageable)));
+        }
+        Page<SurveyResponse> surveyResponsePage = surveyService.getSurveyPageHasRewardForUser(authUser.getEmail(), pageable);
         return CustomResponse.success(new CustomPage(surveyResponsePage));
     }
 
-    //유저에 맞는 리워드 포함 서베이 세개만 제공
-    @GetMapping("/surveys/reward/top3")
-    public CustomResponse getSurveysForReward(@SessionUser AuthUser authUser) {
-        List<SurveyResponse> surveyResponseList = surveyService.getSurveysForRewardTop3(authUser.getEmail());
-        return CustomResponse.success(surveyResponseList);
+
+    //설문이 공개된 서베이 요청
+    @GetMapping("/surveys/open-results")
+    public CustomResponse getSurveyPageShared(@SessionUser(required = false) AuthUser authUser, Pageable pageable) {
+        if (authUser == null) {
+            throw new CustomException(ErrorCode.LOGIN_ERROR);
+        }
+        Page<SurveyResponse> surveyResponsePage = surveyService.getSurveyPageShared(pageable);
+        return CustomResponse.success(new CustomPage(surveyResponsePage));
+    }
+
+    //내가 만든 서베이 요청
+    @GetMapping("/surveys/mine")
+    public CustomResponse getSurveyPageMy(@SessionUser AuthUser authUser, Pageable pageable) {
+        Page<SurveyResponse> surveyResponsePage = surveyService.getSurveyPageMy(authUser.getEmail(), pageable);
+        return CustomResponse.success(new CustomPage(surveyResponsePage));
     }
 
 

--- a/src/main/java/com/pnu/sursim/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/pnu/sursim/domain/survey/repository/SurveyRepository.java
@@ -28,7 +28,21 @@ public interface SurveyRepository extends JpaRepository<Survey, Long> {
     Page<Survey> findAllByAgeAndGenderAndHasReward(LocalDate birthDate, Gender gender, Pageable pageable);
 
 
+    //마감일자가 끝나지 않은 서베이 조회
     @Query("SELECT s FROM Survey s WHERE s.dueDate >= CURRENT_DATE")
     Page<Survey> findAllByDueDateAfter(Pageable pageable);
+
+    //마감일자가 끝나지 않은 서베이 중에서 리워드를 가진 것만 조회
+    @Query("SELECT s FROM Survey s WHERE " +
+            "s.rewardStatus = com.pnu.sursim.domain.survey.entity.RewardStatus.HAS_REWARD AND " +
+            "s.dueDate >= CURRENT_DATE")
+    Page<Survey> findAllByDueDateAfterAndHasReward(Pageable pageable);
+
+
+    Page<Survey> findAllByCreatorId(Long id, Pageable pageable);
+
+    @Query("SELECT s FROM Survey s WHERE s.publicAccess = com.pnu.sursim.domain.survey.entity.PublicAccess.SHARED " +
+            "AND s.dueDate < CURRENT_DATE")
+    Page<Survey> findAllPublicSurveysWithExpiredDueDate(Pageable pageable);
 
 }

--- a/src/main/java/com/pnu/sursim/global/auth/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/pnu/sursim/global/auth/interceptor/AuthInterceptor.java
@@ -29,8 +29,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         Cookie[] cookies = request.getCookies();
 
         if (cookies == null) {
-            response.sendRedirect("/api/login/kakao");
-            throw new CustomException(ErrorCode.TOKEN_EMPTY);
+            return true;
         }
         for (Cookie cookie : cookies) {
             if (cookie.getName().equals("Authorization")) {
@@ -39,8 +38,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         }
 
         if (authorization == null) {
-            response.sendRedirect("/api/login/kakao");
-            throw new CustomException(ErrorCode.TOKEN_EXPIRED);
+            return true;
         }
 
         String token = authorization;

--- a/src/main/java/com/pnu/sursim/global/auth/resolver/SessionUser.java
+++ b/src/main/java/com/pnu/sursim/global/auth/resolver/SessionUser.java
@@ -6,4 +6,5 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface SessionUser {
+    boolean required() default true;
 }

--- a/src/main/java/com/pnu/sursim/global/auth/resolver/SessionUserArgumentResolver.java
+++ b/src/main/java/com/pnu/sursim/global/auth/resolver/SessionUserArgumentResolver.java
@@ -1,6 +1,8 @@
 package com.pnu.sursim.global.auth.resolver;
 
 import com.pnu.sursim.domain.user.dto.AuthUser;
+import com.pnu.sursim.global.exception.CustomException;
+import com.pnu.sursim.global.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.core.MethodParameter;
@@ -20,9 +22,30 @@ public class SessionUserArgumentResolver implements HandlerMethodArgumentResolve
     @Override //넣어줄 반환값을 넣어준다.
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        //request 가 null 인 상황 -> AssertionError 발생
         assert request != null;
-        HttpSession session = request.getSession();
-        return session.getAttribute("user");
+        // null 일 수 있는 상황 : 예외적인 상황에서 발생 (잘못된 요청 흐름,비동기 처리 중 오류, Mocking/Test 환경)
+
+        // 세션이 없을 때 새로 생성하지 않도록 설정
+        HttpSession session = request.getSession(false);
+
+        // @SessionUser 어노테이션이 붙어 있으면 그 어노테이션 객체를 반환하고, 없으면 null을 반환
+        SessionUser sessionUserAnnotation = parameter.getParameterAnnotation(SessionUser.class);
+
+        // 어노테이션의 required 속성을 확인 (어노테이션이 있고, true일 경우)
+        boolean isRequired = sessionUserAnnotation != null && sessionUserAnnotation.required(); // 기본값은 true
+
+        // 세션에서 "user" 속성 가져오기
+        Object user = (session != null) ? session.getAttribute("user") : null;
+
+        // required가 true인데 user 값이 없으면 예외 발생
+        if (isRequired && user == null) {
+            throw new CustomException(ErrorCode.LOGIN_REQUIRED);
+        }
+
+        // required가 false이거나 user가 있는 경우 해당 user 반환
+        return user;
     }
 
 }

--- a/src/main/java/com/pnu/sursim/global/exception/CustomException.java
+++ b/src/main/java/com/pnu/sursim/global/exception/CustomException.java
@@ -7,16 +7,19 @@ import org.springframework.http.HttpStatus;
 public class CustomException extends RuntimeException {
 
     private final HttpStatus httpStatus;
+    private final String code;
 
     public CustomException(ErrorCode errorCode) {
         super(errorCode.getErrorMessage());
         this.httpStatus = errorCode.getHttpStatus();
+        this.code = errorCode.getCode();
 
     }
 
     public CustomException(ErrorCode errorCode, String error) {
         super(errorCode.getErrorMessage() + error);
         this.httpStatus = errorCode.getHttpStatus();
+        this.code = errorCode.getCode();
 
     }
 
@@ -24,5 +27,7 @@ public class CustomException extends RuntimeException {
     public String getMessage() {
         return super.getMessage();
     }
+
+
 
 }

--- a/src/main/java/com/pnu/sursim/global/exception/ErrorCode.java
+++ b/src/main/java/com/pnu/sursim/global/exception/ErrorCode.java
@@ -6,56 +6,59 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     //회원가입
-    EMAIL_EXISTS(HttpStatus.BAD_REQUEST, "This email already exists."),
-    EMPTY_VALUE_NOT_POSSIBLE(HttpStatus.BAD_REQUEST, "Contains an invalid value."),
+    EMAIL_EXISTS(HttpStatus.BAD_REQUEST, "이 이메일은 이미 존재합니다.", "AU001"),
+    EMPTY_VALUE_NOT_POSSIBLE(HttpStatus.BAD_REQUEST, "잘못된 값이 포함되어 있습니다.", "AU002"),
 
     //로그인
-    LOGIN_ERROR(HttpStatus.BAD_REQUEST, "Invalid email and password."),
-    KAKAO_LOGIN_ERROR_NO_USER(HttpStatus.BAD_REQUEST, "User information could not be received from Kakao. The token may be incorrect."),
+    LOGIN_ERROR(HttpStatus.BAD_REQUEST, "이메일 또는 비밀번호가 잘못되었습니다.", "AU003"),
+    KAKAO_LOGIN_ERROR_NO_USER(HttpStatus.BAD_REQUEST, "카카오에서 사용자 정보를 받을 수 없습니다. 토큰이 잘못되었을 수 있습니다.", "AU004"),
+    LOGIN_REQUIRED(HttpStatus.BAD_REQUEST, "로그인이 필요합니다.", "AU005"),
 
     //토큰
-    TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "Your session has expired."),
-    TOKEN_EMPTY(HttpStatus.BAD_REQUEST, "There is no token information."),
+    TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "세션이 만료되었습니다.", "AU006"),
+    TOKEN_EMPTY(HttpStatus.BAD_REQUEST, "토큰 정보가 없습니다.", "AU007"),
 
     //회원
-    USER_ERROR(HttpStatus.BAD_REQUEST, "There is no member information."),
+    USER_ERROR(HttpStatus.BAD_REQUEST, "회원 정보를 찾을 수 없습니다.", "AU008"),
 
-    //설문조사관련응답
-    SURVEY_ALREADY_HAS_REWARDS(HttpStatus.BAD_REQUEST, "The survey already has reward information. Please contact the developer or administrator."),
-    SURVEY_UNAUTHORIZED_USER(HttpStatus.BAD_REQUEST, "The logged in user does not have access to the survey."),
-    SURVEY_NO_REWARDS(HttpStatus.BAD_REQUEST, "There is no reward information in this survey.  Please contact the developer."),
-    SURVEY_DOES_NOT_EXIST(HttpStatus.BAD_REQUEST, "There is no survey matching that ID value."),
-    INCORRECT_CHOICE_QUESTION(HttpStatus.BAD_REQUEST, "An error occurred in the CHOICE_QUESTION. This may be a wrong survey. Please contact the developer."),
-    INCORRECT_SEMANTIC_QUESTIONS(HttpStatus.BAD_REQUEST, "An error occurred in the SEMANTIC_QUESTIONS. This may be a wrong survey. Please contact the developer."),
-    INCORRECT_QUESTION(HttpStatus.BAD_REQUEST, "There was a problem with the survey questions. Please contact the administrator."),
+    //설문조사 관련 응답
+    SURVEY_ALREADY_HAS_REWARDS(HttpStatus.BAD_REQUEST, "이 설문에는 이미 리워드 정보가 있습니다. 개발자 또는 관리자에게 문의하십시오.", "SR001"),
+    SURVEY_UNAUTHORIZED_USER(HttpStatus.BAD_REQUEST, "로그인한 사용자는 이 설문에 접근할 권한이 없습니다.", "SR002"),
+    SURVEY_NO_REWARDS(HttpStatus.BAD_REQUEST, "이 설문에는 리워드 정보가 없습니다. 개발자에게 문의하십시오.", "SR003"),
+    SURVEY_DOES_NOT_EXIST(HttpStatus.BAD_REQUEST, "해당 ID 값에 맞는 설문이 존재하지 않습니다.", "SR004"),
+    INCORRECT_CHOICE_QUESTION(HttpStatus.BAD_REQUEST, "선택형 질문에서 오류가 발생했습니다. 잘못된 설문일 수 있습니다. 개발자에게 문의하십시오.", "SR005"),
+    INCORRECT_SEMANTIC_QUESTIONS(HttpStatus.BAD_REQUEST, "의미 질문에서 오류가 발생했습니다. 잘못된 설문일 수 있습니다. 개발자에게 문의하십시오.", "SR006"),
+    INCORRECT_QUESTION(HttpStatus.BAD_REQUEST, "설문 질문에 문제가 발생했습니다. 관리자에게 문의하십시오.", "SR007"),
 
-    REWARD_REQUEST_INVALID(HttpStatus.BAD_REQUEST,"The reward request value is invalid."),
+    REWARD_REQUEST_INVALID(HttpStatus.BAD_REQUEST, "리워드 요청 값이 유효하지 않습니다.", "SR008"),
 
-    //이미지업로드 중 오류
-    ERROR_UPLOADING_IMAGE(HttpStatus.BAD_REQUEST, "An error occurred while uploading s3. Please contact the developer."),
+    //이미지 업로드 중 오류
+    ERROR_UPLOADING_IMAGE(HttpStatus.BAD_REQUEST, "S3에 이미지를 업로드하는 중 오류가 발생했습니다. 개발자에게 문의하십시오.", "IM001"),
 
     //설문조사에 응답 과정 중 에러
-    SURVEY_AGE_AND_USER_AGE_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "Users cannot respond to the survey. The age does not match."),
-    SURVEY_GENDER_AND_USER_GENDER_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "Users cannot respond to the survey. The gender does not match."),
-    SURVEY_ANSWER_EXISTS(HttpStatus.BAD_REQUEST, "This question has already been answered. You cannot respond twice"),
-    SURVEY_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "Surveys require consent."),
-    QUESTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "The question cannot be found."),
-    INCORRECT_SURVEY_ANSWER(HttpStatus.BAD_REQUEST, "Required response is missing."),
-    INCORRECT_QUESTION_TYPE(HttpStatus.BAD_REQUEST, "The question type of the response is incorrect."),
-    MULTIPLE_INCORRECT_QUESTIONS(HttpStatus.BAD_REQUEST, "The user's response is incorrect."),
-    INCORRECT_OPTIONS_ANSWER(HttpStatus.BAD_REQUEST, "There is no option matching the \"index\" value of the option responded by the user."),
+    SURVEY_AGE_AND_USER_AGE_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "사용자는 이 설문에 응답할 수 없습니다. 나이가 맞지 않습니다.", "SR009"),
+    SURVEY_GENDER_AND_USER_GENDER_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "사용자는 이 설문에 응답할 수 없습니다. 성별이 맞지 않습니다.", "SR010"),
+    SURVEY_ANSWER_EXISTS(HttpStatus.BAD_REQUEST, "이 질문은 이미 응답되었습니다. 두 번 응답할 수 없습니다.", "SR011"),
+    SURVEY_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "설문 응답에는 동의가 필요합니다.", "SR012"),
+    QUESTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 질문을 찾을 수 없습니다.", "SR013"),
+    INCORRECT_SURVEY_ANSWER(HttpStatus.BAD_REQUEST, "필수 응답이 누락되었습니다.", "SR014"),
+    INCORRECT_QUESTION_TYPE(HttpStatus.BAD_REQUEST, "응답의 질문 유형이 올바르지 않습니다.", "SR015"),
+    MULTIPLE_INCORRECT_QUESTIONS(HttpStatus.BAD_REQUEST, "사용자의 응답이 잘못되었습니다.", "SR016"),
+    INCORRECT_OPTIONS_ANSWER(HttpStatus.BAD_REQUEST, "사용자가 응답한 옵션의 \"index\" 값과 일치하는 옵션이 없습니다.", "SR017"),
 
-    //get
-    GPT_ERROR(HttpStatus.BAD_REQUEST,"An error occurred while requesting gpt."),
-    ;
+    //GPT 관련 에러
+    GPT_ERROR(HttpStatus.BAD_REQUEST, "GPT 요청 중 오류가 발생했습니다.", "GP001");
+
 
     private final HttpStatus httpStatus;
     private final String errorMessage;
+    private final String code;
 
 
-    ErrorCode(HttpStatus httpStatus, String errorMessage) {
+    ErrorCode(HttpStatus httpStatus, String errorMessage, String code) {
         this.httpStatus = httpStatus;
         this.errorMessage = errorMessage;
+        this.code = code;
     }
 
 }

--- a/src/main/java/com/pnu/sursim/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pnu/sursim/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.pnu.sursim.global.exception;
 
 import com.pnu.sursim.global.response.CustomResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -10,13 +12,15 @@ public class GlobalExceptionHandler {
 
     @ResponseBody
     @ExceptionHandler(Exception.class)
-    public CustomResponse handleGeneralException(Exception exception) {
-        return CustomResponse.fail(exception);
+    public ResponseEntity handleGeneralException(Exception exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CustomResponse.fail(exception));
     }
 
     @ResponseBody
     @ExceptionHandler(CustomException.class)
-    public CustomResponse handleGeneralException(CustomException customException) {
-        return CustomResponse.fail(customException);
+    public ResponseEntity handleGeneralException(CustomException customException) {
+        return ResponseEntity.status(customException.getHttpStatus())
+                .body(CustomResponse.fail(customException));
     }
 }

--- a/src/main/java/com/pnu/sursim/global/response/CustomResponse.java
+++ b/src/main/java/com/pnu/sursim/global/response/CustomResponse.java
@@ -11,24 +11,24 @@ import org.springframework.http.HttpStatus;
 public class CustomResponse {
 
     private HttpStatus httpStatus;
-    private int code;
+    private String code;
     private Object content;
 
-    private CustomResponse(HttpStatus httpStatus, Object content) {
+    private CustomResponse(HttpStatus httpStatus, String code, Object content) {
         this.httpStatus = httpStatus;
-        this.code = httpStatus.value();
+        this.code = code;
         this.content = content;
     }
 
     public static CustomResponse success(Object object) {
-        return new CustomResponse(HttpStatus.OK, object);
+        return new CustomResponse(HttpStatus.OK, "OK001", object);
     }
 
     public static CustomResponse fail(CustomException customException) {
-        return new CustomResponse(customException.getHttpStatus(), customException.getMessage());
+        return new CustomResponse(customException.getHttpStatus(), customException.getCode(), customException.getMessage());
     }
 
     public static CustomResponse fail(Exception exception) {
-        return new CustomResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
+        return new CustomResponse(HttpStatus.BAD_REQUEST,"ER001", exception.getMessage());
     }
 }


### PR DESCRIPTION
## 📖️ 설문조사 조회 & 로그인 필요한 요청 & 에러 반환 형태 변경

연관 이슈 : #31 #26 

## 변경 기능

### 설문조사 조회 
- 이슈에서 작성한것과는 다르게 엔드포인트로 두었음
- 유저가 로그인했을때에 따라서 유저 전용 or 아닌 경우는 전체 값으로 자동 요청 (클라이언트에서 신경쓰지 않아도 되도록)

1. 내가 만든 서베이 : `/surveys/mine`
2. 진행 중 서베이 : `/surveys`
3. 진행중 & 리워드 서베이 : `/surveys/has-reward`
4. 마감 & 공개 서베이  : `/surveys/open-results`

###  로그인 필요한 요청 
- 어노테이션의 `required`값과 리졸버에서 필 수 인데 로그인이 안된경우 에러를 반환하도록 변경

### 에러 반환 형태 변경
- 클라이언트에서 HTTP 상태 코드와, 자체 에러 코드 값으로 에러를 더 편하게 볼 수 있도록 변경
![image](https://github.com/user-attachments/assets/391bfc95-e7b6-416c-b7a0-7e26c28c85ed)
